### PR TITLE
Fix bugs causing it to not launch

### DIFF
--- a/.dev.env
+++ b/.dev.env
@@ -1,5 +1,5 @@
 HOST_LABEL=
-y
+
 # Only used in development (away from full node)
 THIRD_PARTY_HTTP=https://mainnet.infura.io/v3/<add-api-key>
 THIRD_PARTY_WS=wss://mainnet.infura.io/ws/v3/<add-api-key>
@@ -12,6 +12,13 @@ PG_DB=dev_db_name
 # Docker development variables
 DB_HOST_PATH=
 DB_CONTAINER_PATH=/var/lib/postgresql/data
+
+CACHE_HOST_PATH=./cache
+CACHE_CONTAINER_PATH=/data
+
+RABBITMQ_USER=rabbitmq
+RABBITMQ_PASS=rabbitmqpass
+
 
 # Host Names (Containers)
 DB_HOST=db

--- a/.prod.env
+++ b/.prod.env
@@ -1,4 +1,5 @@
 HOST_LABEL=node
+HOST_IP_ADDR=0.0.0.0
 
 # PostgreSQL environment variables
 PG_PASSWORD=postgres
@@ -6,8 +7,15 @@ PG_USER=postgres
 PG_DB=fresh_db
 
 # Docker environment variables
-DB_HOST_PATH=
+DB_HOST_PATH=./db
 DB_CONTAINER_PATH=/var/lib/postgresql/data
+
+CACHE_HOST_PATH=./cache
+CACHE_CONTAINER_PATH=/data
+
+RABBITMQ_USER=rabbitmq
+RABBITMQ_PASS=rabbitmqpass
+
 
 # Host Names (Containers)
 DB_HOST=db

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:18-alpine
 
 WORKDIR /usr/src/app
 

--- a/scripts/wait_for_db.sh
+++ b/scripts/wait_for_db.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 echo "Running wait script"
 
 # Sleep is necessary for enabling the init_db script called by the temporary db_setup container to execute and create a fresh database in the case it doesn't exist

--- a/src/services/api/index.api.ts
+++ b/src/services/api/index.api.ts
@@ -22,7 +22,8 @@ async function run() {
   const PORT = process.env.SERVICE_PORT;
 
   const rabbit_wrapper = new Broker();
-  await waitForPort(5672);
+  const rabbit_host = process.env.RABBITMQ_HOST || '0.0.0.0';
+  await waitForPort(5672, rabbit_host);
   await initDataStores();
 
   try {

--- a/src/services/core/index.core.ts
+++ b/src/services/core/index.core.ts
@@ -19,8 +19,10 @@ async function run() {
   await initDataStores();
 
   Cache.getInstance();
+  
+  const rabbit_host = process.env.RABBITMQ_HOST || '0.0.0.0';
+  await waitForPort(5672, rabbit_host);
 
-  await waitForPort(5672);
 
   try {
     await rabbit_wrapper.init();

--- a/src/services/scraper/index.scraper.ts
+++ b/src/services/scraper/index.scraper.ts
@@ -29,7 +29,8 @@ async function run() {
   // Instantiate broker
   const rabbit_wrapper = new Broker();
   // Wait for RabbitMQ server to be up and running
-  await waitForPort(5672);
+  const rabbit_host = process.env.RABBITMQ_HOST || '0.0.0.0';
+  await waitForPort(5672, rabbit_host);
 
   /* Seed data */
   if (process.env.SEED === 'yes') {

--- a/src/utils/ports.utils.ts
+++ b/src/utils/ports.utils.ts
@@ -1,9 +1,9 @@
 import { check } from 'tcp-port-used';
 import ip from 'ip';
 
-async function isReady(port_num: number) {
+async function isReady(port_num: number, host: string) {
   try {
-    const inUse = await check(port_num, process.env.HOST_IP_ADDR);
+    const inUse = await check(port_num, host);
     return inUse;
   } catch (err) {
     console.error(err);
@@ -24,7 +24,7 @@ function timeout(ms: number, label: string) {
  * Poll until a process is running on the supplied port number (it is important to know what host we are referring to here! -> see HOST_IP_ADDR for inter-container communication)
  * @param {number} port_num - port number of running process
  */
-async function waitForPort(port_num: number) {
+async function waitForPort(port_num: number, host: string) {
   const PORT_LABEL_MAP: IPortMap = {
     5672: 'RabbitMQ',
     5000: 'scraper',
@@ -32,7 +32,7 @@ async function waitForPort(port_num: number) {
     5002: 'api',
   };
 
-  while (!(await isReady(port_num))) {
+  while (!(await isReady(port_num, host))) {
     await timeout(1000, PORT_LABEL_MAP[port_num]);
   }
 }


### PR DESCRIPTION
Containers weren't talking to each other using `localhost` or `0.0.0.0` but did work via hostname, so added the ability to specify hostnames for them and have that used in the `waitForService` checks. Also added some more sane default env variables. 